### PR TITLE
Improve ngrok URL retrieval

### DIFF
--- a/LocalServer/app/main.py
+++ b/LocalServer/app/main.py
@@ -9,7 +9,9 @@ from app.routers import (
 )
 from app.routers import mail
 
-NGROK_URL = get_ngrok_url()
+# Allow a few more retries when resolving the ngrok URL so the server can
+# start even if the tunnel is not immediately ready.
+NGROK_URL = get_ngrok_url(retries=10)
 
 app = FastAPI(
     title="3on3 MCP File Pipeline",


### PR DESCRIPTION
## Summary
- enhance `get_ngrok_url` with env override and better logging
- allow more retries when looking up ngrok URL in `main.py`

## Testing
- `python LocalServer/test.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6862228fdbd48328928fccda8345c744