### PR TITLE
Add env-based DB configuration

### DIFF
--- a/LocalServer/app/utils.py
+++ b/LocalServer/app/utils.py
@@ -39,14 +39,31 @@ def get_ngrok_url(
     return fallback
 
 def get_db_connection(
-    database: str = "master", *, retries: int = 3, delay: float = 1.0
+    database: str | None = None, *, retries: int = 3, delay: float = 1.0
 ):
-    """Connect to SQL Server with simple retry logic."""
+    """Connect to SQL Server with simple retry logic.
+
+    Connection parameters can be customised using the following environment
+    variables with the shown defaults:
+
+    - ``MSSQL_SERVER`` (``10.31.20.6``)
+    - ``MSSQL_USER`` (``sa``)
+    - ``MSSQL_PASSWORD`` (``f$ei#L!sa``)
+    - ``MSSQL_DATABASE`` (``master`` when ``database`` argument is ``None``)
+    """
+
+    server = os.environ.get("MSSQL_SERVER", "10.31.20.6")
+    user = os.environ.get("MSSQL_USER", "sa")
+    password = os.environ.get("MSSQL_PASSWORD", "f$ei#L!sa")
+    default_db = os.environ.get("MSSQL_DATABASE", "master")
+    if database is None:
+        database = default_db
+
     conn_str = (
         "DRIVER={ODBC Driver 17 for SQL Server};"
-        "SERVER=10.31.20.6;"
+        f"SERVER={server};"
         f"DATABASE={database};"
-        "UID=sa;PWD=f$ei#L!sa"
+        f"UID={user};PWD={password}"
     )
     last_error = None
     for attempt in range(1, retries + 1):

--- a/LocalServer/start.bat
+++ b/LocalServer/start.bat
@@ -7,6 +7,12 @@ set ROOT_DIR=%~dp0
 REM === 2. (필요시) 가상환경 활성화 ===
 REM call "%ROOT_DIR%\.venv\Scripts\activate"
 
+REM === DB 접속 정보 설정 ===
+IF NOT DEFINED MSSQL_SERVER set "MSSQL_SERVER=10.31.20.6"
+IF NOT DEFINED MSSQL_USER set "MSSQL_USER=sa"
+IF NOT DEFINED MSSQL_PASSWORD set "MSSQL_PASSWORD=f$ei#L!sa"
+IF NOT DEFINED MSSQL_DATABASE set "MSSQL_DATABASE=master"
+
 REM === 3. 프로젝트 루트로 이동 ===
 cd /d "%ROOT_DIR%"
 

--- a/LocalServer/start_mcp.bat
+++ b/LocalServer/start_mcp.bat
@@ -6,6 +6,12 @@ set ROOT_DIR=%~dp0
 
 cd /d "%ROOT_DIR%"
 
+:: DB connection settings
+IF NOT DEFINED MSSQL_SERVER set "MSSQL_SERVER=10.31.20.6"
+IF NOT DEFINED MSSQL_USER set "MSSQL_USER=sa"
+IF NOT DEFINED MSSQL_PASSWORD set "MSSQL_PASSWORD=f$ei#L!sa"
+IF NOT DEFINED MSSQL_DATABASE set "MSSQL_DATABASE=master"
+
 :: Start ngrok first
 echo [INFO] Starting ngrok...
 start "ngrok" "%ROOT_DIR%ngrok.exe" http 8000 > "%ROOT_DIR%ngrok.log" 2>&1

--- a/LocalServer/start_server.bat
+++ b/LocalServer/start_server.bat
@@ -4,6 +4,12 @@ setlocal enabledelayedexpansion
 set ROOT_DIR=%~dp0
 cd /d "%ROOT_DIR%"
 
+:: DB connection settings
+IF NOT DEFINED MSSQL_SERVER set "MSSQL_SERVER=10.31.20.6"
+IF NOT DEFINED MSSQL_USER set "MSSQL_USER=sa"
+IF NOT DEFINED MSSQL_PASSWORD set "MSSQL_PASSWORD=f$ei#L!sa"
+IF NOT DEFINED MSSQL_DATABASE set "MSSQL_DATABASE=master"
+
 :: Start ngrok first so that the FastAPI server advertises the public URL
 echo [INFO] Starting ngrok...
 start "ngrok" "%ROOT_DIR%ngrok.exe" http 8000 > "%ROOT_DIR%ngrok.log" 2>&1


### PR DESCRIPTION
## Summary
- allow overriding DB connection info in `get_db_connection`
- document environment variables in all batch scripts

## Testing
- `python -m py_compile LocalServer/app/utils.py`
- `python LocalServer/test.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6862249133b883289b786d8aa262dc74